### PR TITLE
Update documentation link README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 LISFLOOD plugin for [eWatercycle](https://ewatercycle.readthedocs.io/).
 
-LISFLOOD documentation at http://www.smhi.net/lisflood/wiki/doku.php .
+LISFLOOD documentation [here](https://ec-jrc.github.io/lisflood-model/).
 
 ## Installation
 


### PR DESCRIPTION
old documentation link: http://www.smhi.net/lisflood/wiki/doku.php  was no longer working, since migrated to https://ec-jrc.github.io/lisflood-model/