### PR TITLE
Update tests & CI for ewatercycle 2.3.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,19 +9,16 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.10"]
-      fail-fast: false
-    name: Run tests in mamba environment ${{ matrix.python-version }}
+    name: Run tests in mamba environment
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Download mamba environment.yml
         run:
-          wget https://raw.githubusercontent.com/eWaterCycle/ewatercycle/main/environment.yml
+          wget https://raw.githubusercontent.com/eWaterCycle/ewatercycle/main/conda-lock.yml
       - uses: mamba-org/setup-micromamba@v1
         with:
-          environment-file: environment.yml
+          environment-file: conda-lock.yml
+          environment-name: ci
           cache-environment: true
           init-shell: bash
       - name: Install dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 
 # Include here only the dependencies for the eWaterCycle wrapped model
 dependencies = [
-  "ewatercycle>=2.0.0b2",
+  "ewatercycle>=2.3.1",
 ]
 dynamic = ["version"]
 

--- a/tests/test_forcing.py
+++ b/tests/test_forcing.py
@@ -101,6 +101,8 @@ class TestGenerateForcingWithoutLisvap:
             """\
         start_time: '1989-01-02T00:00:00Z'
         end_time: '1999-01-02T00:00:00Z'
+        shape: Rhine.shp
+        filenames: {}
         PrefixPrecipitation: lisflood_pr.nc
         PrefixTavg: lisflood_tas.nc
         PrefixE0: e0.nc
@@ -113,8 +115,7 @@ class TestGenerateForcingWithoutLisvap:
 
     def test_saved_yaml(self, forcing, tmp_path):
         saved_forcing = LisfloodForcing.load(tmp_path)
-        # shape should is not included in the yaml file
-        forcing.shape = None
+        forcing.shape = forcing.directory / "Rhine.shp"
 
         assert forcing == saved_forcing
 


### PR DESCRIPTION
- CI uses conda lock now
- new eWaterCycle version is pinned
- Tests have been updated